### PR TITLE
Upgrade to Filament v5 (Livewire v4)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,5 +43,13 @@ jobs:
       - name: List Installed Dependencies
         run: composer show -D
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright
+        run: npm install playwright && npx playwright install chromium
+
       - name: Execute tests
         run: vendor/bin/pest --ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Install Playwright
         run: pnpm add playwright && pnpm exec playwright install chromium
 
+      - name: Set up Filament assets
+        run: php vendor/bin/testbench filament:assets
+
       - name: Execute tests
         run: vendor/bin/pest --ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,8 +48,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Playwright
-        run: npm install playwright && npx playwright install chromium
+        run: pnpm add playwright && pnpm exec playwright install chromium
 
       - name: Execute tests
         run: vendor/bin/pest --ci

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/forms": "^4.0",
+        "filament/forms": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
-        "filament/filament": "^4.0",
+        "filament/filament": "^5.0",
         "laravel/boost": "^2",
         "laravel/pint": "^1.25",
         "nunomaduro/collision": "^8.8.2",

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -46,6 +46,11 @@ class BrowserTestCase extends Orchestra
         ];
     }
 
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
## Summary

- Bump `filament/forms` and `filament/filament` constraints from `^4.0` to `^5.0`
- Add `APP_KEY` to `BrowserTestCase` — Livewire v4's cookie middleware now requires encryption, which was not needed with Livewire v3

Filament v5 has zero functional API changes from v4; the major version bump is solely due to requiring Livewire v4 instead of v3.

## Test plan

- [x] All 13 browser tests pass (34 assertions)
- [ ] Manual smoke test via `composer serve` on the Create Post page